### PR TITLE
Update A Bottom-Up Introduction to Gen.ipynb

### DIFF
--- a/tutorials/A Bottom-Up Introduction to Gen.ipynb
+++ b/tutorials/A Bottom-Up Introduction to Gen.ipynb
@@ -524,13 +524,13 @@
     "figure(figsize=(12, 2))\n",
     "\n",
     "subplot(1, 3, 1)\n",
-    "query(0.1, 14)\n",
+    "gen_query(0.1, 14)\n",
     "\n",
     "subplot(1, 3, 2)\n",
-    "query(0.5, 14)\n",
+    "gen_query(0.5, 14)\n",
     "\n",
     "subplot(1, 3, 3)\n",
-    "query(0.9, 14);"
+    "gen_query(0.9, 14);"
    ]
   },
   {


### PR DESCRIPTION
we should use the newly defined "gen_query" function as opposed to the old "query" function