### PR TITLE
Dockerfile for Ubuntu 20.04 and Python 3.8

### DIFF
--- a/Dockerfile.ubuntu-2004
+++ b/Dockerfile.ubuntu-2004
@@ -1,0 +1,48 @@
+FROM            ubuntu:20.04
+MAINTAINER      MIT Probabilistic Computing Project
+
+# Avoid tzdata configuration dialog
+ENV             DEBIAN_FRONTEND=noninteractive
+
+RUN             apt update -qq && apt install -qq -y \
+                    hdf5-tools \
+                    git \
+                    python3-dev \
+                    python3-pip \
+                    python3-tk \
+                    wget \
+                    zlib1g-dev && \
+                rm -rf /var/lib/apt/lists/*
+
+# Since Tensorflow only supports Python up to 3.7 and not 3.8 (default in 20.04) instead of tensorflow or tf-nightly-cpu we use
+# Tensorflow wheel files from https://pypi.org/project/tf-nightly/2.2.0.dev20200307/#files
+RUN             wget https://files.pythonhosted.org/packages/30/8e/650b282491e126a39e2b256f1ad790d566c53465dfd801a7703e421431e3/tf_nightly-2.2.0.dev20200307-cp38-cp38-manylinux2010_x86_64.whl && \
+                python3 -m pip install --upgrade pip && \
+                python3 -m pip install tf_nightly-2.2.0.dev20200307-cp38-cp38-manylinux2010_x86_64.whl && \
+                rm tf_nightly-2.2.0.dev20200307-cp38-cp38-manylinux2010_x86_64.whl
+
+RUN             git config --global user.name "Gen User"
+RUN             git config --global user.email "email@example.com"
+
+# Could use virtual environment - "RUN virtualenv -p /usr/bin/python3 /venv" and ". /venv/bin/activate" && in front of pip and julia commands
+RUN             python3 -m pip install jupyter jupytext matplotlib
+
+RUN             wget https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz && \
+                tar -xzv < julia-1.3.1-linux-x86_64.tar.gz && \
+                ln -s /julia-1.3.1/bin/julia /usr/bin/julia && \
+                rm julia-1.3.1-linux-x86_64.tar.gz
+
+ADD             . /gen-quickstart
+ENV             JULIA_PROJECT=/gen-quickstart
+
+RUN             julia -e 'using Pkg; Pkg.build()' && julia -e 'using Pkg; Pkg.API.precompile()'
+
+WORKDIR         /gen-quickstart
+
+ENTRYPOINT      jupyter notebook \
+                    --ip='0.0.0.0' \
+                    --port=8080 \
+                    --no-browser \
+                    --NotebookApp.token= \
+                    --allow-root \
+                    --NotebookApp.iopub_data_rate_limit=-1


### PR DESCRIPTION
This is a Dockerfile for cutting edge versions - it is based on the upcoming Ubuntu 20.04 which will be released in slightly over a month and uses a nightly Tensorflow build that already works with Python 3.8 (regular Tensorflow only supports up to 3.7). This image ensures that besides the existing conservative Ubuntu 16.04 containerization we also keep an eye on upcoming developments.