### PR TITLE
Add PyTorch install to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN             git config --global user.name "Gen User"
 RUN             git config --global user.email "email@example.com"
 
 RUN             virtualenv -p /usr/bin/python3 /venv
-RUN             . /venv/bin/activate && pip install jupyter jupytext matplotlib tensorflow
+RUN             . /venv/bin/activate && pip install jupyter jupytext matplotlib tensorflow torch
 
 RUN             wget https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz
 RUN             tar -xzv < julia-1.3.1-linux-x86_64.tar.gz


### PR DESCRIPTION
## Why

After this, some tutorials will be modified/extended to use [GenPyTorch](https://github.com/probcomp/GenPyTorch.jl/blob/master/src/GenPyTorch.jl).

## Tested

Build succeeded, and the image is now deployed as [probcomp/gen-quickstart:2020-03-24.001](https://hub.docker.com/layers/probcomp/gen-quickstart/2020-03-24.001/images/sha256-7778960c9a728611536c57aa0c532f775599ed28289f9a0c4f5e702663573b68?context=explore).