### PR TITLE
Change `print(choicemap)` to simply `choicemap`

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,10 +1,16 @@
 # This file is machine-generated - editing it directly is not advised
 
 [[Arpack]]
-deps = ["BinaryProvider", "Libdl", "LinearAlgebra"]
-git-tree-sha1 = "cd64c112638582ba4f0be9c3e20656499c508565"
+deps = ["Arpack_jll", "Libdl", "LinearAlgebra"]
+git-tree-sha1 = "2ff92b71ba1747c5fdd541f8fc87736d82f40ec9"
 uuid = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
-version = "0.3.2"
+version = "0.4.0"
+
+[[Arpack_jll]]
+deps = ["Libdl", "OpenBLAS_jll", "Pkg"]
+git-tree-sha1 = "68a90a692ddc0eb72d69a6993ca26e2a923bf195"
+uuid = "68821587-b530-5797-8361-c406ea357684"
+version = "3.5.0+2"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -22,16 +28,16 @@ uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.8"
 
 [[Blosc]]
-deps = ["BinaryProvider", "CMakeWrapper", "Compat", "Libdl"]
-git-tree-sha1 = "71fb23581e1f0b0ae7be8ccf0ebfb3600e23ca41"
+deps = ["BinaryProvider", "CMakeWrapper", "Libdl"]
+git-tree-sha1 = "9981f1795919b8f770dc064fe733ba09c2e7c7a9"
 uuid = "a74b3585-a348-5f62-a45c-50e91977d574"
-version = "0.5.1"
+version = "0.6.0"
 
 [[CMake]]
 deps = ["BinDeps"]
-git-tree-sha1 = "c67a8689dc5444adc5eb2be7d837100340ecba11"
+git-tree-sha1 = "50a8b41d2c562fccd9ab841085fc7d1e2706da82"
 uuid = "631607c0-34d2-5d66-819e-eb0f9aa2061a"
-version = "1.1.2"
+version = "1.2.0"
 
 [[CMakeWrapper]]
 deps = ["BinDeps", "CMake", "Libdl", "Parameters", "Test"]
@@ -63,11 +69,17 @@ git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "2.2.0"
 
+[[CompilerSupportLibraries_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "7c4f882c41faa72118841185afc58a2eb00ef612"
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.3.3+0"
+
 [[Conda]]
 deps = ["JSON", "VersionParsing"]
-git-tree-sha1 = "9a11d428dcdc425072af4aea19ab1e8c3e01c032"
+git-tree-sha1 = "7a58bb32ce5d85f8bf7559aa7c2842f9aecf52fc"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.3.0"
+version = "1.4.1"
 
 [[DataAPI]]
 git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
@@ -76,15 +88,15 @@ version = "1.1.0"
 
 [[DataDeps]]
 deps = ["HTTP", "Reexport", "SHA"]
-git-tree-sha1 = "795b99df0963831ddeefbe9ac05721ffd9475c04"
+git-tree-sha1 = "f2be642d7a94e7f0cabcd2106fee4c6715d452d1"
 uuid = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
-version = "0.7.1"
+version = "0.7.2"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "b7720de347734f4716d1815b00ce5664ed6bbfd4"
+git-tree-sha1 = "73eb18320fe3ba58790c8b8f6f89420f0a622773"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.9"
+version = "0.17.11"
 
 [[Dates]]
 deps = ["Printf"]
@@ -102,9 +114,9 @@ version = "1.0.2"
 
 [[DiffRules]]
 deps = ["NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "10dca52cf6d4a62d82528262921daf63b99704a2"
+git-tree-sha1 = "eb0c34204c8410888844ada5359ac8b96292cfd1"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.0.0"
+version = "1.0.1"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -118,18 +130,18 @@ version = "0.22.4"
 
 [[FileIO]]
 deps = ["Pkg"]
-git-tree-sha1 = "74585bf1f7ed7259e166011e89f49363d7fa89a6"
+git-tree-sha1 = "3d7cb2c4c850439f19c4d6d3fbe1dce6481cddb1"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.2.1"
+version = "1.2.4"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "fec413d4fc547992eb62a5c544cedb6d7853c1f5"
+git-tree-sha1 = "3eb5253af6186eada40de3df524a1c10f0c6bfa2"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.8.4"
+version = "0.8.6"
 
 [[FixedPointNumbers]]
 git-tree-sha1 = "4aaea64dd0c30ad79037084f8ca2b94348e65eaa"
@@ -138,15 +150,14 @@ version = "0.7.1"
 
 [[ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "NaNMath", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "88b082d492be6b63f967b6c96b352e25ced1a34c"
+git-tree-sha1 = "869540e4367122fbffaace383a5bdc34d6e5e5ac"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.9"
+version = "0.10.10"
 
 [[FunctionWrappers]]
-deps = ["Compat"]
-git-tree-sha1 = "49bf793ebd37db5adaa7ac1eae96c2c97ec86db5"
+git-tree-sha1 = "e4813d187be8c7b993cb7f85cbf2b7bfbaadc694"
 uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
-version = "1.0.0"
+version = "1.1.1"
 
 [[FunctionalCollections]]
 deps = ["Test"]
@@ -162,7 +173,7 @@ version = "0.5.1"
 
 [[Gen]]
 deps = ["DataStructures", "Distributions", "FunctionalCollections", "JSON", "LinearAlgebra", "MacroTools", "Random", "ReverseDiff", "SpecialFunctions"]
-git-tree-sha1 = "8b1686eca997088b31541e4a2b92d479bf2de24d"
+git-tree-sha1 = "e8a12d045fe36dfddb7e2019f42d8179ae6f2b3f"
 repo-rev = "master"
 repo-url = "https://github.com/probcomp/Gen"
 uuid = "ea4f424c-a589-11e8-07c0-fd5c91b9da4a"
@@ -192,15 +203,15 @@ version = "0.12.5"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
-git-tree-sha1 = "5c49dab19938b119fe204fd7d7e8e174f4e9c68b"
+git-tree-sha1 = "cd60d9a575d3b70c026d7e714212fd4ecf86b4bb"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.8.8"
+version = "0.8.13"
 
 [[IJulia]]
 deps = ["Base64", "Conda", "Dates", "InteractiveUtils", "JSON", "Markdown", "MbedTLS", "Pkg", "Printf", "REPL", "Random", "SoftGlobalScope", "Test", "UUIDs", "ZMQ"]
-git-tree-sha1 = "468b6290cd10ed30732fde36207c64034386c5ef"
+git-tree-sha1 = "b60c883405f31b90c5a7b6862e1d21caad5b411a"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.21.0"
+version = "1.21.1"
 
 [[IniFile]]
 deps = ["Test"]
@@ -225,10 +236,9 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LaTeXStrings]]
-deps = ["Compat"]
-git-tree-sha1 = "7ab9b8788cfab2bdde22adf9004bda7ad9954b6c"
+git-tree-sha1 = "de44b395389b84fd681394d4e8d39ef14e3a2ea8"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-version = "1.0.3"
+version = "1.1.0"
 
 [[LegacyStrings]]
 deps = ["Compat"]
@@ -237,6 +247,7 @@ uuid = "1b4a561d-cfcb-5daf-8433-43fcf8b4bea3"
 version = "0.4.1"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -256,20 +267,20 @@ uuid = "eb30cadb-4394-5ae3-aed4-317e484a6458"
 version = "0.4.0"
 
 [[MacroTools]]
-deps = ["DataStructures", "Markdown", "Random"]
-git-tree-sha1 = "07ee65e03e28ca88bc9a338a3726ae0c3efaa94b"
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "f7d2e3f654af75f01ec49be82c231c382214223a"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.4"
+version = "0.5.5"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MbedTLS]]
-deps = ["BinaryProvider", "Dates", "Distributed", "Libdl", "Random", "Sockets", "Test"]
-git-tree-sha1 = "2d94286a9c2f52c63a16146bb86fd6cdfbf677c6"
+deps = ["BinaryProvider", "Dates", "Libdl", "Random", "Sockets"]
+git-tree-sha1 = "85f5947b53c8cfd53ccfa3f4abae31faa22c2181"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "0.6.8"
+version = "0.7.0"
 
 [[Missings]]
 deps = ["DataAPI"]
@@ -285,6 +296,18 @@ git-tree-sha1 = "928b8ca9b2791081dc71a51c55347c27c618760f"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 version = "0.3.3"
 
+[[OpenBLAS_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "72163ef83570d258af87ed91f301c5b51a5e08e9"
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.9+0"
+
+[[OpenSpecFun_jll]]
+deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "d51c416559217d974a1113522d5919235ae67a87"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.3+3"
+
 [[OrderedCollections]]
 deps = ["Random", "Serialization", "Test"]
 git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
@@ -293,9 +316,9 @@ version = "1.1.0"
 
 [[PDMats]]
 deps = ["Arpack", "LinearAlgebra", "SparseArrays", "SuiteSparse", "Test"]
-git-tree-sha1 = "5f303510529486bb02ac4d70da8295da38302194"
+git-tree-sha1 = "2fc6f50ddd959e462f0a2dbc802ddf2a539c6e35"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.9.11"
+version = "0.9.12"
 
 [[Parameters]]
 deps = ["OrderedCollections"]
@@ -305,12 +328,12 @@ version = "0.12.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "d112c19ccca00924d5d3a38b11ae2b4b268dda39"
+git-tree-sha1 = "75d07cb840c300084634b4991761886d0d762724"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.11"
+version = "1.0.1"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -357,15 +380,21 @@ version = "1.0.1"
 
 [[ReverseDiff]]
 deps = ["DiffResults", "DiffRules", "ForwardDiff", "FunctionWrappers", "LinearAlgebra", "NaNMath", "Random", "SpecialFunctions", "StaticArrays", "Statistics"]
-git-tree-sha1 = "6a5aae862f93c577f89a607334f09630439ec119"
+git-tree-sha1 = "5f7dafd314ff2ada3076797b1edfb71e52151cb9"
 uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-version = "1.0.0"
+version = "1.1.0"
 
 [[Rmath]]
-deps = ["BinaryProvider", "Libdl", "Random", "Statistics"]
-git-tree-sha1 = "2bbddcb984a1d08612d0c4abb5b4774883f6fa98"
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "86c5647b565873641538d8f812c04e4c9dbeb370"
 uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
-version = "0.6.0"
+version = "0.6.1"
+
+[[Rmath_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "1660f8fefbf5ab9c67560513131d4e933012fc4b"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.2.2+0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -397,10 +426,10 @@ deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["BinDeps", "BinaryProvider", "Libdl"]
-git-tree-sha1 = "3bdd374b6fd78faf0119b8c5d538788dbf910c6e"
+deps = ["OpenSpecFun_jll"]
+git-tree-sha1 = "e19b98acb182567bcb7b75bb5d9eedf3a3b5ec6c"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "0.8.0"
+version = "0.10.0"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
@@ -420,12 +449,12 @@ version = "0.32.0"
 
 [[StatsFuns]]
 deps = ["Rmath", "SpecialFunctions"]
-git-tree-sha1 = "79982835d2ff3970685cb704500909c94189bde9"
+git-tree-sha1 = "f290ddd5fdedeadd10e961eb3f4d3340f09d030a"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "0.9.3"
+version = "0.9.4"
 
 [[SuiteSparse]]
-deps = ["Libdl", "LinearAlgebra", "SparseArrays"]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[Test]]
@@ -451,7 +480,13 @@ uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
 version = "1.2.0"
 
 [[ZMQ]]
-deps = ["BinaryProvider", "FileWatching", "Libdl", "Sockets"]
-git-tree-sha1 = "5d7d4aec57689992f08672e5ff459bde7d105abd"
+deps = ["FileWatching", "Sockets", "ZeroMQ_jll"]
+git-tree-sha1 = "adb2d52aa12c8284da12714f35d2b21fc3d5b2bb"
 uuid = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
-version = "1.1.0"
+version = "1.2.0"
+
+[[ZeroMQ_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "d24fc0004686b534cc7518412b626deeea0b0208"
+uuid = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
+version = "4.3.2+1"

--- a/tutorials/A Bottom-Up Introduction to Gen.ipynb
+++ b/tutorials/A Bottom-Up Introduction to Gen.ipynb
@@ -442,7 +442,7 @@
    "source": [
     "using Gen: get_choices\n",
     "\n",
-    "display(get_choices(trace))"
+    "get_choices(trace)"
    ]
   },
   {
@@ -1151,15 +1151,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.1.1",
+   "display_name": "Julia 1.4.0",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.1"
+   "version": "1.4.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/A Bottom-Up Introduction to Gen.ipynb
+++ b/tutorials/A Bottom-Up Introduction to Gen.ipynb
@@ -1148,6 +1148,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,jl:light"
+  },
   "kernelspec": {
    "display_name": "Julia 1.4.0",
    "language": "julia",

--- a/tutorials/A Bottom-Up Introduction to Gen.ipynb
+++ b/tutorials/A Bottom-Up Introduction to Gen.ipynb
@@ -629,7 +629,7 @@
    "source": [
     "using Gen: get_score\n",
     "trace = simulate(foo, (0.3,))\n",
-    "display(get_choices(trace))\n",
+    "get_choices(trace)\n",
     "println(\"log probability: $(get_score(trace))\")"
    ]
   },
@@ -681,9 +681,7 @@
    "source": [
     "using Gen: choicemap\n",
     "\n",
-    "constraints = choicemap((:a, true), (:c, false))\n",
-    "\n",
-    "display(constraints)"
+    "constraints = choicemap((:a, true), (:c, false))"
    ]
   },
   {
@@ -732,7 +730,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(get_choices(trace))"
+    "get_choices(trace)"
    ]
   },
   {

--- a/tutorials/A Bottom-Up Introduction to Gen.ipynb
+++ b/tutorials/A Bottom-Up Introduction to Gen.ipynb
@@ -442,7 +442,7 @@
    "source": [
     "using Gen: get_choices\n",
     "\n",
-    "println(get_choices(trace))"
+    "display(get_choices(trace))"
    ]
   },
   {
@@ -629,7 +629,7 @@
    "source": [
     "using Gen: get_score\n",
     "trace = simulate(foo, (0.3,))\n",
-    "println(get_choices(trace))\n",
+    "display(get_choices(trace))\n",
     "println(\"log probability: $(get_score(trace))\")"
    ]
   },
@@ -683,7 +683,7 @@
     "\n",
     "constraints = choicemap((:a, true), (:c, false))\n",
     "\n",
-    "println(constraints)"
+    "display(constraints)"
    ]
   },
   {
@@ -732,7 +732,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "println(get_choices(trace))"
+    "display(get_choices(trace))"
    ]
   },
   {
@@ -1154,6 +1154,12 @@
    "display_name": "Julia 1.1.1",
    "language": "julia",
    "name": "julia-1.1"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.1.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/A Bottom-Up Introduction to Gen.ipynb
+++ b/tutorials/A Bottom-Up Introduction to Gen.ipynb
@@ -629,7 +629,7 @@
    "source": [
     "using Gen: get_score\n",
     "trace = simulate(foo, (0.3,))\n",
-    "get_choices(trace)\n",
+    "display(get_choices(trace))\n",
     "println(\"log probability: $(get_score(trace))\")"
    ]
   },

--- a/tutorials/A Bottom-Up Introduction to Gen.jl
+++ b/tutorials/A Bottom-Up Introduction to Gen.jl
@@ -361,7 +361,7 @@ end
 
 using Gen: get_score
 trace = simulate(foo, (0.3,))
-get_choices(trace)
+display(get_choices(trace))
 println("log probability: $(get_score(trace))")
 
 # Check this value against the hand-computed value in our table above.

--- a/tutorials/A Bottom-Up Introduction to Gen.jl
+++ b/tutorials/A Bottom-Up Introduction to Gen.jl
@@ -265,7 +265,7 @@ trace[:initial_n]
 # +
 using Gen: get_choices
 
-println(get_choices(trace))
+display(get_choices(trace))
 # -
 
 # Gen also stores the arguments on which the function was called:
@@ -360,7 +360,7 @@ end
 
 using Gen: get_score
 trace = simulate(foo, (0.3,))
-println(get_choices(trace))
+display(get_choices(trace))
 println("log probability: $(get_score(trace))")
 
 # Check this value against the hand-computed value in our table above.
@@ -388,7 +388,7 @@ using Gen: choicemap
 
 constraints = choicemap((:a, true), (:c, false))
 
-println(constraints)
+display(constraints)
 # -
 
 # The `choicemap` constructor above took two elements of the form `(address, value`). This is equivalent to constructing an empty choice map and then populating it:
@@ -411,7 +411,7 @@ using Gen: generate
 #
 # Let's check that the trace actually agrees with our constraints:
 
-println(get_choices(trace))
+display(get_choices(trace))
 
 # We can also check the return value:
 

--- a/tutorials/A Bottom-Up Introduction to Gen.jl
+++ b/tutorials/A Bottom-Up Introduction to Gen.jl
@@ -1,15 +1,16 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,jl:light
 #     text_representation:
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
 #       jupytext_version: 1.3.3
 #   kernelspec:
-#     display_name: Julia 1.1.1
+#     display_name: Julia 1.4.0
 #     language: julia
-#     name: julia-1.1
+#     name: julia-1.4
 # ---
 
 # # A Bottom-Up Introduction to Gen
@@ -265,7 +266,7 @@ trace[:initial_n]
 # +
 using Gen: get_choices
 
-display(get_choices(trace))
+get_choices(trace)
 # -
 
 # Gen also stores the arguments on which the function was called:
@@ -360,7 +361,7 @@ end
 
 using Gen: get_score
 trace = simulate(foo, (0.3,))
-display(get_choices(trace))
+get_choices(trace)
 println("log probability: $(get_score(trace))")
 
 # Check this value against the hand-computed value in our table above.
@@ -387,8 +388,6 @@ println("log probability: $(get_score(trace))")
 using Gen: choicemap
 
 constraints = choicemap((:a, true), (:c, false))
-
-display(constraints)
 # -
 
 # The `choicemap` constructor above took two elements of the form `(address, value`). This is equivalent to constructing an empty choice map and then populating it:
@@ -411,7 +410,7 @@ using Gen: generate
 #
 # Let's check that the trace actually agrees with our constraints:
 
-display(get_choices(trace))
+get_choices(trace)
 
 # We can also check the return value:
 

--- a/tutorials/Data-Driven Proposals in Gen.ipynb
+++ b/tutorials/Data-Driven Proposals in Gen.ipynb
@@ -479,7 +479,7 @@
    "outputs": [],
    "source": [
     "(proposed_choices, _, _) = Gen.propose(custom_dest_proposal, (measurements, scene))\n",
-    "println(proposed_choices)"
+    "display(proposed_choices)"
    ]
   },
   {
@@ -1495,6 +1495,12 @@
    "display_name": "Julia 1.1.1",
    "language": "julia",
    "name": "julia-1.1"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.1.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/Data-Driven Proposals in Gen.ipynb
+++ b/tutorials/Data-Driven Proposals in Gen.ipynb
@@ -479,7 +479,7 @@
    "outputs": [],
    "source": [
     "(proposed_choices, _, _) = Gen.propose(custom_dest_proposal, (measurements, scene))\n",
-    "display(proposed_choices)"
+    "proposed_choices"
    ]
   },
   {
@@ -1492,15 +1492,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.1.1",
+   "display_name": "Julia 1.4.0",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.1"
+   "version": "1.4.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/Data-Driven Proposals in Gen.ipynb
+++ b/tutorials/Data-Driven Proposals in Gen.ipynb
@@ -1491,6 +1491,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,jl:light"
+  },
   "kernelspec": {
    "display_name": "Julia 1.4.0",
    "language": "julia",

--- a/tutorials/Data-Driven Proposals in Gen.jl
+++ b/tutorials/Data-Driven Proposals in Gen.jl
@@ -1,15 +1,16 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,jl:light
 #     text_representation:
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
 #       jupytext_version: 1.3.3
 #   kernelspec:
-#     display_name: Julia 1.1.1
+#     display_name: Julia 1.4.0
 #     language: julia
-#     name: julia-1.1
+#     name: julia-1.4
 # ---
 
 # # Tutorial: Data-Driven Proposals in Gen
@@ -280,7 +281,7 @@ end;
 # We can propose values of random choices from the proposal function using [`Gen.propose`](https://probcomp.github.io/Gen/dev/ref/gfi/#Gen.propose). This method returns the choices, as well as some other information, which we won't need for our purposes. For now, you can think of `Gen.propose` as similar to `Gen.initialize` except that it does not produce a full execution trace (only the choices), and it does not accept constraints. We can see the random choices for one run of the proposal on our data set:
 
 (proposed_choices, _, _) = Gen.propose(custom_dest_proposal, (measurements, scene))
-display(proposed_choices)
+proposed_choices
 
 # The function below runs the proposal 1000 times. For each run, it generates a trace of the model where the `:dest_x` and `:dest_y` choices are constrained to the proposed values, and then visualizes the resulting traces. We make the proposal a parameter of the function because we will be visualizing the output distribution of various proposals later in the notebook.
 

--- a/tutorials/Data-Driven Proposals in Gen.jl
+++ b/tutorials/Data-Driven Proposals in Gen.jl
@@ -280,7 +280,7 @@ end;
 # We can propose values of random choices from the proposal function using [`Gen.propose`](https://probcomp.github.io/Gen/dev/ref/gfi/#Gen.propose). This method returns the choices, as well as some other information, which we won't need for our purposes. For now, you can think of `Gen.propose` as similar to `Gen.initialize` except that it does not produce a full execution trace (only the choices), and it does not accept constraints. We can see the random choices for one run of the proposal on our data set:
 
 (proposed_choices, _, _) = Gen.propose(custom_dest_proposal, (measurements, scene))
-println(proposed_choices)
+display(proposed_choices)
 
 # The function below runs the proposal 1000 times. For each run, it generates a trace of the model where the `:dest_x` and `:dest_y` choices are constrained to the proposed values, and then visualizes the resulting traces. We make the proposal a parameter of the function because we will be visualizing the output distribution of various proposals later in the notebook.
 

--- a/tutorials/Introduction to Modeling in Gen.ipynb
+++ b/tutorials/Introduction to Modeling in Gen.ipynb
@@ -290,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(Gen.get_choices(trace))"
+    "Gen.get_choices(trace)"
    ]
   },
   {
@@ -1169,7 +1169,7 @@
    "outputs": [],
    "source": [
     "trace = Gen.simulate(bar, ())\n",
-    "display(Gen.get_choices(trace))"
+    "Gen.get_choices(trace)"
    ]
   },
   {
@@ -1186,7 +1186,7 @@
    "outputs": [],
    "source": [
     "trace = Gen.simulate(bar_using_namespace, ())\n",
-    "display(Gen.get_choices(trace))"
+    "Gen.get_choices(trace)"
    ]
   },
   {
@@ -1828,15 +1828,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.1.1",
+   "display_name": "Julia 1.4.0",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.1"
+   "version": "1.4.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/Introduction to Modeling in Gen.ipynb
+++ b/tutorials/Introduction to Modeling in Gen.ipynb
@@ -1827,6 +1827,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,jl:light"
+  },
   "kernelspec": {
    "display_name": "Julia 1.4.0",
    "language": "julia",

--- a/tutorials/Introduction to Modeling in Gen.ipynb
+++ b/tutorials/Introduction to Modeling in Gen.ipynb
@@ -290,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "println(Gen.get_choices(trace))"
+    "display(Gen.get_choices(trace))"
    ]
   },
   {
@@ -1169,7 +1169,7 @@
    "outputs": [],
    "source": [
     "trace = Gen.simulate(bar, ())\n",
-    "println(Gen.get_choices(trace))"
+    "display(Gen.get_choices(trace))"
    ]
   },
   {
@@ -1186,7 +1186,7 @@
    "outputs": [],
    "source": [
     "trace = Gen.simulate(bar_using_namespace, ())\n",
-    "println(Gen.get_choices(trace))"
+    "display(Gen.get_choices(trace))"
    ]
   },
   {

--- a/tutorials/Introduction to Modeling in Gen.jl
+++ b/tutorials/Introduction to Modeling in Gen.jl
@@ -1,15 +1,16 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,jl:light
 #     text_representation:
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
 #       jupytext_version: 1.3.3
 #   kernelspec:
-#     display_name: Julia 1.1.1
+#     display_name: Julia 1.4.0
 #     language: julia
-#     name: julia-1.1
+#     name: julia-1.4
 # ---
 
 # # Tutorial: Introduction to Modeling in Gen
@@ -127,7 +128,7 @@ Gen.get_args(trace)
 
 # The trace also contains the value of the random choices, stored in a map from address to value called a *choice map*. This map is available through the API method [`get_choices`]():
 
-display(Gen.get_choices(trace))
+Gen.get_choices(trace)
 
 # We can pull out individual values from this map using Julia's subscripting syntax `[...]`:
 
@@ -539,12 +540,12 @@ end;
 # We first show the addresses sampled by `bar`:
 
 trace = Gen.simulate(bar, ())
-display(Gen.get_choices(trace))
+Gen.get_choices(trace)
 
 # And the addresses sampled by `bar_using_namespace`:
 
 trace = Gen.simulate(bar_using_namespace, ())
-display(Gen.get_choices(trace))
+Gen.get_choices(trace)
 
 # Using `@trace` with a namespace can help avoid address collisions for complex models.
 

--- a/tutorials/Introduction to Modeling in Gen.jl
+++ b/tutorials/Introduction to Modeling in Gen.jl
@@ -127,7 +127,7 @@ Gen.get_args(trace)
 
 # The trace also contains the value of the random choices, stored in a map from address to value called a *choice map*. This map is available through the API method [`get_choices`]():
 
-println(Gen.get_choices(trace))
+display(Gen.get_choices(trace))
 
 # We can pull out individual values from this map using Julia's subscripting syntax `[...]`:
 
@@ -539,12 +539,12 @@ end;
 # We first show the addresses sampled by `bar`:
 
 trace = Gen.simulate(bar, ())
-println(Gen.get_choices(trace))
+display(Gen.get_choices(trace))
 
 # And the addresses sampled by `bar_using_namespace`:
 
 trace = Gen.simulate(bar_using_namespace, ())
-println(Gen.get_choices(trace))
+display(Gen.get_choices(trace))
 
 # Using `@trace` with a namespace can help avoid address collisions for complex models.
 

--- a/tutorials/Iterative inference in Gen.ipynb
+++ b/tutorials/Iterative inference in Gen.ipynb
@@ -1198,7 +1198,8 @@
  ],
  "metadata": {
   "jupytext": {
-   "encoding": "# -*- coding: utf-8 -*-"
+   "encoding": "# -*- coding: utf-8 -*-",
+   "formats": "ipynb,jl:light"
   },
   "kernelspec": {
    "display_name": "Julia 1.4.0",

--- a/tutorials/Iterative inference in Gen.ipynb
+++ b/tutorials/Iterative inference in Gen.ipynb
@@ -1201,15 +1201,15 @@
    "encoding": "# -*- coding: utf-8 -*-"
   },
   "kernelspec": {
-   "display_name": "Julia 1.1.1",
+   "display_name": "Julia 1.4.0",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.1"
+   "version": "1.4.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/Iterative inference in Gen.ipynb
+++ b/tutorials/Iterative inference in Gen.ipynb
@@ -1204,6 +1204,12 @@
    "display_name": "Julia 1.1.1",
    "language": "julia",
    "name": "julia-1.1"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.1.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/Iterative inference in Gen.jl
+++ b/tutorials/Iterative inference in Gen.jl
@@ -2,15 +2,16 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,jl:light
 #     text_representation:
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
 #       jupytext_version: 1.3.3
 #   kernelspec:
-#     display_name: Julia 1.1.1
+#     display_name: Julia 1.4.0
 #     language: julia
-#     name: julia-1.1
+#     name: julia-1.4
 # ---
 
 # # Tutorial: Basics of Iterative Inference Programming in Gen

--- a/tutorials/Modeling with Black-Box Julia Code.ipynb
+++ b/tutorials/Modeling with Black-Box Julia Code.ipynb
@@ -390,8 +390,7 @@
    "source": [
     "planner_params = PlannerParams(300, 3.0, 2000, 1.)\n",
     "(trace, _) = Gen.generate(agent_model, (scene, dt, num_ticks, planner_params));\n",
-    "choices = Gen.get_choices(trace)\n",
-    "display(choices)"
+    "choices = Gen.get_choices(trace)"
    ]
   },
   {
@@ -680,15 +679,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.1.1",
+   "display_name": "Julia 1.4.0",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.1"
+   "version": "1.4.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/Modeling with Black-Box Julia Code.ipynb
+++ b/tutorials/Modeling with Black-Box Julia Code.ipynb
@@ -391,7 +391,7 @@
     "planner_params = PlannerParams(300, 3.0, 2000, 1.)\n",
     "(trace, _) = Gen.generate(agent_model, (scene, dt, num_ticks, planner_params));\n",
     "choices = Gen.get_choices(trace)\n",
-    "println(choices)"
+    "display(choices)"
    ]
   },
   {
@@ -680,9 +680,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Cora Julia 1.1.1",
+   "display_name": "Julia 1.1.1",
    "language": "julia",
-   "name": "cora-julia-1.1"
+   "name": "julia-1.1"
   },
   "language_info": {
    "file_extension": ".jl",

--- a/tutorials/Modeling with Black-Box Julia Code.ipynb
+++ b/tutorials/Modeling with Black-Box Julia Code.ipynb
@@ -678,6 +678,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,jl:light"
+  },
   "kernelspec": {
    "display_name": "Julia 1.4.0",
    "language": "julia",

--- a/tutorials/Modeling with Black-Box Julia Code.jl
+++ b/tutorials/Modeling with Black-Box Julia Code.jl
@@ -1,15 +1,16 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,jl:light
 #     text_representation:
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
 #       jupytext_version: 1.3.3
 #   kernelspec:
-#     display_name: Cora Julia 1.1.1
+#     display_name: Julia 1.4.0
 #     language: julia
-#     name: cora-julia-1.1
+#     name: julia-1.4
 # ---
 
 # # Modeling with black-box Julia code 
@@ -166,7 +167,6 @@ end;
 planner_params = PlannerParams(300, 3.0, 2000, 1.)
 (trace, _) = Gen.generate(agent_model, (scene, dt, num_ticks, planner_params));
 choices = Gen.get_choices(trace)
-display(choices)
 
 # Next we explore the assumptions of the model by sampling many traces from the generative function and visualizing them. We have created a visualization specialized for this generative function for use with the `GenViz` package, in the directory `../inverse-planning/grid-viz/dist`. We have also defined a `trace_to_dict` method to convert the trace into a value that can be automatically serialized into a JSON string for use by the visualization:
 

--- a/tutorials/Modeling with Black-Box Julia Code.jl
+++ b/tutorials/Modeling with Black-Box Julia Code.jl
@@ -166,7 +166,7 @@ end;
 planner_params = PlannerParams(300, 3.0, 2000, 1.)
 (trace, _) = Gen.generate(agent_model, (scene, dt, num_ticks, planner_params));
 choices = Gen.get_choices(trace)
-println(choices)
+display(choices)
 
 # Next we explore the assumptions of the model by sampling many traces from the generative function and visualizing them. We have created a visualization specialized for this generative function for use with the `GenViz` package, in the directory `../inverse-planning/grid-viz/dist`. We have also defined a `trace_to_dict` method to convert the trace into a value that can be automatically serialized into a JSON string for use by the visualization:
 

--- a/tutorials/Modeling with TensorFlow Code.ipynb
+++ b/tutorials/Modeling with TensorFlow Code.ipynb
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "println(Gen.get_choices(trace))"
+    "display(Gen.get_choices(trace))"
    ]
   },
   {
@@ -246,7 +246,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "println(Gen.get_choices(trace))"
+    "display(Gen.get_choices(trace))"
    ]
   },
   {

--- a/tutorials/Modeling with TensorFlow Code.ipynb
+++ b/tutorials/Modeling with TensorFlow Code.ipynb
@@ -526,6 +526,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,jl:light"
+  },
   "kernelspec": {
    "display_name": "Julia 1.4.0",
    "language": "julia",

--- a/tutorials/Modeling with TensorFlow Code.ipynb
+++ b/tutorials/Modeling with TensorFlow Code.ipynb
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(Gen.get_choices(trace))"
+    "Gen.get_choices(trace)"
    ]
   },
   {
@@ -246,7 +246,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(Gen.get_choices(trace))"
+    "Gen.get_choices(trace)"
    ]
   },
   {
@@ -527,15 +527,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.1.1",
+   "display_name": "Julia 1.4.0",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.1"
+   "version": "1.4.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/Modeling with TensorFlow Code.jl
+++ b/tutorials/Modeling with TensorFlow Code.jl
@@ -1,15 +1,16 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,jl:light
 #     text_representation:
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
 #       jupytext_version: 1.3.3
 #   kernelspec:
-#     display_name: Julia 1.1.1
+#     display_name: Julia 1.4.0
 #     language: julia
-#     name: julia-1.1
+#     name: julia-1.4
 # ---
 
 # # Modeling with TensorFlow code
@@ -78,7 +79,7 @@ println(size(probs))
 
 #  Note that generative functions constructed using GenTF do not make random choices:
 
-display(Gen.get_choices(trace))
+Gen.get_choices(trace)
 
 # The return value is the Julia value corresponding to the Tensor `y`:
 
@@ -107,7 +108,7 @@ end;
 
 # We see that the `net` generative function does not make any random choices. The only random choices are the digit labels for each input input:
 
-display(Gen.get_choices(trace))
+Gen.get_choices(trace)
 
 # Before the `digit_model` will be useful for anything, it needs to be trained. We load some code for loading batches of MNIST training data.
 

--- a/tutorials/Modeling with TensorFlow Code.jl
+++ b/tutorials/Modeling with TensorFlow Code.jl
@@ -78,7 +78,7 @@ println(size(probs))
 
 #  Note that generative functions constructed using GenTF do not make random choices:
 
-println(Gen.get_choices(trace))
+display(Gen.get_choices(trace))
 
 # The return value is the Julia value corresponding to the Tensor `y`:
 
@@ -107,7 +107,7 @@ end;
 
 # We see that the `net` generative function does not make any random choices. The only random choices are the digit labels for each input input:
 
-println(Gen.get_choices(trace))
+display(Gen.get_choices(trace))
 
 # Before the `digit_model` will be useful for anything, it needs to be trained. We load some code for loading batches of MNIST training data.
 

--- a/tutorials/Particle Filtering in Gen.ipynb
+++ b/tutorials/Particle Filtering in Gen.ipynb
@@ -526,7 +526,7 @@
    "outputs": [],
    "source": [
     "trace = Gen.simulate(chain, (4, State(0., 0., 0., 0.), 0.01, 0.01))\n",
-    "println(Gen.get_choices(trace))"
+    "display(Gen.get_choices(trace))"
    ]
   },
   {
@@ -584,7 +584,7 @@
    "outputs": [],
    "source": [
     "(trace, _) = Gen.generate(unfold_model, (4,))\n",
-    "println(Gen.get_choices(trace))"
+    "display(Gen.get_choices(trace))"
    ]
   },
   {

--- a/tutorials/Particle Filtering in Gen.ipynb
+++ b/tutorials/Particle Filtering in Gen.ipynb
@@ -526,7 +526,7 @@
    "outputs": [],
    "source": [
     "trace = Gen.simulate(chain, (4, State(0., 0., 0., 0.), 0.01, 0.01))\n",
-    "display(Gen.get_choices(trace))"
+    "Gen.get_choices(trace)"
    ]
   },
   {
@@ -584,7 +584,7 @@
    "outputs": [],
    "source": [
     "(trace, _) = Gen.generate(unfold_model, (4,))\n",
-    "display(Gen.get_choices(trace))"
+    "Gen.get_choices(trace)"
    ]
   },
   {
@@ -726,15 +726,15 @@
    "encoding": "# -*- coding: utf-8 -*-"
   },
   "kernelspec": {
-   "display_name": "Julia 1.1.1",
+   "display_name": "Julia 1.4.0",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.1"
+   "version": "1.4.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/Particle Filtering in Gen.ipynb
+++ b/tutorials/Particle Filtering in Gen.ipynb
@@ -723,7 +723,8 @@
  ],
  "metadata": {
   "jupytext": {
-   "encoding": "# -*- coding: utf-8 -*-"
+   "encoding": "# -*- coding: utf-8 -*-",
+   "formats": "ipynb,jl:light"
   },
   "kernelspec": {
    "display_name": "Julia 1.4.0",

--- a/tutorials/Particle Filtering in Gen.jl
+++ b/tutorials/Particle Filtering in Gen.jl
@@ -2,15 +2,16 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,jl:light
 #     text_representation:
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
 #       jupytext_version: 1.3.3
 #   kernelspec:
-#     display_name: Julia 1.1.1
+#     display_name: Julia 1.4.0
 #     language: julia
-#     name: julia-1.1
+#     name: julia-1.4
 # ---
 
 # # Tutorial: Particle Filtering in Gen
@@ -339,7 +340,7 @@ Gen.load_generated_functions()
 # We can understand the behavior of `chain` by getting a trace of it and printing the random choices:
 
 trace = Gen.simulate(chain, (4, State(0., 0., 0., 0.), 0.01, 0.01))
-display(Gen.get_choices(trace))
+Gen.get_choices(trace)
 
 # We now write a new version of the generative model that invokes `chain` instead of using the Julia `for` loop:
 
@@ -375,7 +376,7 @@ Gen.load_generated_functions()
 # Let's generate a trace of this new model program to understand its structure:
 
 (trace, _) = Gen.generate(unfold_model, (4,))
-display(Gen.get_choices(trace))
+Gen.get_choices(trace)
 
 function unfold_particle_filter(num_particles::Int, zs::Vector{Float64}, num_samples::Int)
     init_obs = Gen.choicemap((:z0, zs[1]))    

--- a/tutorials/Particle Filtering in Gen.jl
+++ b/tutorials/Particle Filtering in Gen.jl
@@ -339,7 +339,7 @@ Gen.load_generated_functions()
 # We can understand the behavior of `chain` by getting a trace of it and printing the random choices:
 
 trace = Gen.simulate(chain, (4, State(0., 0., 0., 0.), 0.01, 0.01))
-println(Gen.get_choices(trace))
+display(Gen.get_choices(trace))
 
 # We now write a new version of the generative model that invokes `chain` instead of using the Julia `for` loop:
 
@@ -375,7 +375,7 @@ Gen.load_generated_functions()
 # Let's generate a trace of this new model program to understand its structure:
 
 (trace, _) = Gen.generate(unfold_model, (4,))
-println(Gen.get_choices(trace))
+display(Gen.get_choices(trace))
 
 function unfold_particle_filter(num_particles::Int, zs::Vector{Float64}, num_samples::Int)
     init_obs = Gen.choicemap((:z0, zs[1]))    

--- a/tutorials/Reasoning About Regenerate.ipynb
+++ b/tutorials/Reasoning About Regenerate.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "using Gen: get_choices\n",
     "\n",
-    "display(get_choices(trace))"
+    "get_choices(trace)"
    ]
   },
   {
@@ -304,7 +304,7 @@
    "source": [
     "trace, weight = generate(foo, (0.3,), choicemap((:a, true), (:b, false), (:c, true)));\n",
     "(trace, weight, retdiff) = regenerate(trace, (0.3,), (NoChange(),), select(:a));\n",
-    "display(get_choices(trace))\n",
+    "get_choices(trace)\n",
     "println(\"weight: $weight\");"
    ]
   },
@@ -327,15 +327,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.1.1",
+   "display_name": "Julia 1.4.0",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.1"
+   "version": "1.4.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/Reasoning About Regenerate.ipynb
+++ b/tutorials/Reasoning About Regenerate.ipynb
@@ -326,6 +326,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,jl:light"
+  },
   "kernelspec": {
    "display_name": "Julia 1.4.0",
    "language": "julia",

--- a/tutorials/Reasoning About Regenerate.ipynb
+++ b/tutorials/Reasoning About Regenerate.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "using Gen: get_choices\n",
     "\n",
-    "println(get_choices(trace))"
+    "display(get_choices(trace))"
    ]
   },
   {
@@ -304,7 +304,7 @@
    "source": [
     "trace, weight = generate(foo, (0.3,), choicemap((:a, true), (:b, false), (:c, true)));\n",
     "(trace, weight, retdiff) = regenerate(trace, (0.3,), (NoChange(),), select(:a));\n",
-    "println(get_choices(trace))\n",
+    "display(get_choices(trace))\n",
     "println(\"weight: $weight\");"
    ]
   },

--- a/tutorials/Reasoning About Regenerate.jl
+++ b/tutorials/Reasoning About Regenerate.jl
@@ -73,7 +73,7 @@ using Gen: regenerate, select, NoChange
 # +
 using Gen: get_choices
 
-println(get_choices(trace))
+display(get_choices(trace))
 # -
 
 # Re-run the regenerate command until you get a trace where `a` is `false`. Note that the address `b` doesn't appear in the resulting trace. Then, run the command again until you get a trace where `a` is `true`. Note that now there is a value for `b`. This value of `b` was sampled along with the new value for `a`---`regenerate` will regenerate new values for the selected adddresses, but also any new addresses that may be introduced as a consequence of stochastic control flow.
@@ -205,7 +205,7 @@ log((0.7 * 0.9)/(0.3 * 0.4 * 0.2)) + log((0.3 * 0.4)/(0.7))
 
 trace, weight = generate(foo, (0.3,), choicemap((:a, true), (:b, false), (:c, true)));
 (trace, weight, retdiff) = regenerate(trace, (0.3,), (NoChange(),), select(:a));
-println(get_choices(trace))
+display(get_choices(trace))
 println("weight: $weight");
 
 # Aren't we glad this is automated by Gen!

--- a/tutorials/Reasoning About Regenerate.jl
+++ b/tutorials/Reasoning About Regenerate.jl
@@ -1,15 +1,16 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,jl:light
 #     text_representation:
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
 #       jupytext_version: 1.3.3
 #   kernelspec:
-#     display_name: Julia 1.1.1
+#     display_name: Julia 1.4.0
 #     language: julia
-#     name: julia-1.1
+#     name: julia-1.4
 # ---
 
 # # Reasoning About Regenerate
@@ -73,7 +74,7 @@ using Gen: regenerate, select, NoChange
 # +
 using Gen: get_choices
 
-display(get_choices(trace))
+get_choices(trace)
 # -
 
 # Re-run the regenerate command until you get a trace where `a` is `false`. Note that the address `b` doesn't appear in the resulting trace. Then, run the command again until you get a trace where `a` is `true`. Note that now there is a value for `b`. This value of `b` was sampled along with the new value for `a`---`regenerate` will regenerate new values for the selected adddresses, but also any new addresses that may be introduced as a consequence of stochastic control flow.
@@ -205,7 +206,7 @@ log((0.7 * 0.9)/(0.3 * 0.4 * 0.2)) + log((0.3 * 0.4)/(0.7))
 
 trace, weight = generate(foo, (0.3,), choicemap((:a, true), (:b, false), (:c, true)));
 (trace, weight, retdiff) = regenerate(trace, (0.3,), (NoChange(),), select(:a));
-display(get_choices(trace))
+get_choices(trace)
 println("weight: $weight");
 
 # Aren't we glad this is automated by Gen!

--- a/tutorials/Scaling with Combinators and the Static Modeling Language.ipynb
+++ b/tutorials/Scaling with Combinators and the Static Modeling Language.ipynb
@@ -315,7 +315,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "println(get_choices(trace))"
+    "display(get_choices(trace))"
    ]
   },
   {
@@ -356,7 +356,7 @@
    "outputs": [],
    "source": [
     "trace = simulate(model_with_map, (xs,));\n",
-    "println(get_choices(trace))"
+    "display(get_choices(trace))"
    ]
   },
   {
@@ -799,6 +799,12 @@
    "display_name": "Julia 1.1.1",
    "language": "julia",
    "name": "julia-1.1"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.1.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/Scaling with Combinators and the Static Modeling Language.ipynb
+++ b/tutorials/Scaling with Combinators and the Static Modeling Language.ipynb
@@ -795,6 +795,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,jl:light"
+  },
   "kernelspec": {
    "display_name": "Julia 1.4.0",
    "language": "julia",

--- a/tutorials/Scaling with Combinators and the Static Modeling Language.ipynb
+++ b/tutorials/Scaling with Combinators and the Static Modeling Language.ipynb
@@ -315,7 +315,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(get_choices(trace))"
+    "get_choices(trace)"
    ]
   },
   {
@@ -356,7 +356,7 @@
    "outputs": [],
    "source": [
     "trace = simulate(model_with_map, (xs,));\n",
-    "display(get_choices(trace))"
+    "get_choices(trace)"
    ]
   },
   {
@@ -796,15 +796,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.1.1",
+   "display_name": "Julia 1.4.0",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.4"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.1"
+   "version": "1.4.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/Scaling with Combinators and the Static Modeling Language.jl
+++ b/tutorials/Scaling with Combinators and the Static Modeling Language.jl
@@ -169,7 +169,7 @@ trace = simulate(generate_all_points, (xs, prob_outliers, noises, slopes, interc
 
 # We see that the `generate_all_points` function has traced 5 calls to `generate_single_point`, under namespaces `1` through `5`.  The `Map` combinator automatically adds these indices to the trace address.
 
-println(get_choices(trace))
+display(get_choices(trace))
 
 # Now, let's replace the Julia `for` loop in our model with a call to this new function:
 
@@ -186,7 +186,7 @@ end;
 # Note that this new model has the same address structure as our original model had, so our inference code will not need to change. For example, the 5th data point's $y$ coordinate will be stored at the address `:data => 5 => :y`, just as before. (The `:data` comes from our `@trace` invocation in the `better_model` definition, and the `:y` comes from `generate_point`; only the `5` has been inserted automatically by `Map`.)
 
 trace = simulate(model_with_map, (xs,));
-println(get_choices(trace))
+display(get_choices(trace))
 
 # Let's test the running time of the inference program, applied to this new model:
 

--- a/tutorials/Scaling with Combinators and the Static Modeling Language.jl
+++ b/tutorials/Scaling with Combinators and the Static Modeling Language.jl
@@ -1,15 +1,16 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,jl:light
 #     text_representation:
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
 #       jupytext_version: 1.3.3
 #   kernelspec:
-#     display_name: Julia 1.1.1
+#     display_name: Julia 1.4.0
 #     language: julia
-#     name: julia-1.1
+#     name: julia-1.4
 # ---
 
 # # Scaling with Combinators and the Static Modeling Language
@@ -169,7 +170,7 @@ trace = simulate(generate_all_points, (xs, prob_outliers, noises, slopes, interc
 
 # We see that the `generate_all_points` function has traced 5 calls to `generate_single_point`, under namespaces `1` through `5`.  The `Map` combinator automatically adds these indices to the trace address.
 
-display(get_choices(trace))
+get_choices(trace)
 
 # Now, let's replace the Julia `for` loop in our model with a call to this new function:
 
@@ -186,7 +187,7 @@ end;
 # Note that this new model has the same address structure as our original model had, so our inference code will not need to change. For example, the 5th data point's $y$ coordinate will be stored at the address `:data => 5 => :y`, just as before. (The `:data` comes from our `@trace` invocation in the `better_model` definition, and the `:y` comes from `generate_point`; only the `5` has been inserted automatically by `Map`.)
 
 trace = simulate(model_with_map, (xs,));
-display(get_choices(trace))
+get_choices(trace)
 
 # Let's test the running time of the inference program, applied to this new model:
 


### PR DESCRIPTION
Depends on https://github.com/probcomp/Gen/pull/228.

Per https://github.com/probcomp/Gen/issues/227.  As described there, after this I'm planning to move the pretty-printing logic from `Base.show(::IO, ::Gen.ChoiceMap)` to `Base.show(::IO, ::MIME"text/plain", ::Gen.ChoiceMap)`.

## Tested

Loaded one of the notebook locally, and made sure the displaying of choicemaps in the Jupyter notebook works as expected (i.e., pretty-prints).  Also ran [the one cell](https://github.com/probcomp/gen-quickstart/blob/4221c3ff03d7c185ca80eefdccb7baaa1be8e386/tutorials/A%20Bottom-Up%20Introduction%20to%20Gen.jl#L362-L365) where an explicit call to `display` was needed, because the displaying was not the last expression in the cell.